### PR TITLE
Additional DependencyContainer Functions

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -278,6 +278,21 @@ test('resolves all transient instances when not registered', () => {
 
 // --- isRegistered() ---
 
+test('all registered tokens are returned', () => {
+  @injectable()
+  class Bar {}
+
+  @injectable()
+  class Foo {
+    constructor(public bar: Bar) {}
+  }
+
+  globalContainer.registerSingleton(Foo)
+  globalContainer.registerSingleton(Bar)
+
+  expect(globalContainer.registeredTokens().length).toBe(2)
+})
+
 test('returns true for a registered singleton class', () => {
   @injectable()
   class Bar implements IBar {

--- a/src/__tests__/interception.test.ts
+++ b/src/__tests__/interception.test.ts
@@ -1,6 +1,101 @@
 import { instance as globalContainer } from '../dependency-container'
 
-// beforeResolution .resolve() tests
+// MARK: After Registration
+
+test('afterRegistration interceptor gets called correctly', () => {
+  class Foo {}
+  const fn = jest.fn()
+
+  globalContainer.afterRegistration(Foo, fn)
+  globalContainer.register(Foo, { useClass: Foo })
+
+  expect(fn).toBeCalled()
+})
+
+test('afterRegistration interceptor does not get called when registering other types', () => {
+  class Foo {}
+  class Bar {}
+  const fn = jest.fn()
+
+  globalContainer.afterRegistration(Foo, fn)
+  globalContainer.register(Bar, { useClass: Bar })
+
+  expect(fn).not.toHaveBeenCalled()
+})
+
+test('afterRegistration one-time interceptor only gets called once', () => {
+  class Foo {}
+  const fn = jest.fn()
+
+  globalContainer.afterRegistration(Foo, fn, {
+    frequency: 'Once',
+  })
+  globalContainer.register(Foo, { useClass: Foo })
+  globalContainer.register(Foo, { useClass: Foo })
+
+  expect(fn).toBeCalledTimes(1)
+})
+
+test('afterRegistration always run interceptor gets called on each registration', () => {
+  class Foo {}
+  const fn = jest.fn()
+
+  globalContainer.afterRegistration(Foo, fn)
+  globalContainer.register(Foo, { useClass: Foo })
+  globalContainer.register(Foo, { useClass: Foo })
+
+  expect(fn).toBeCalledTimes(2)
+})
+
+test('afterRegistration multiple interceptors get called correctly', () => {
+  class Foo {}
+  const fn1 = jest.fn()
+  const fn2 = jest.fn()
+
+  globalContainer.afterRegistration(Foo, fn1, {
+    frequency: 'Once',
+  })
+  globalContainer.afterRegistration(Foo, fn2, {
+    frequency: 'Once',
+  })
+  globalContainer.register(Foo, { useClass: Foo })
+
+  expect(fn1).toBeCalled()
+  expect(fn2).toBeCalled()
+})
+
+test('afterRegistration multiple interceptors get per their options', () => {
+  class Foo {}
+  const fn1 = jest.fn()
+  const fn2 = jest.fn()
+
+  globalContainer.afterRegistration(Foo, fn1, {
+    frequency: 'Once',
+  })
+  globalContainer.afterRegistration(Foo, fn2, {
+    frequency: 'Always',
+  })
+  globalContainer.register(Foo, { useClass: Foo })
+  globalContainer.register(Foo, { useClass: Foo })
+
+  expect(fn1).toBeCalledTimes(1)
+  expect(fn2).toBeCalledTimes(2)
+})
+
+test('afterAnyRegistration interceptor gets called on each registration', () => {
+  class Foo {}
+  class Bar {}
+  const fn = jest.fn()
+
+  globalContainer.afterAnyRegistration(fn)
+  globalContainer.register(Foo, { useClass: Foo })
+  globalContainer.register(Bar, { useClass: Bar })
+
+  expect(fn).toBeCalledTimes(2)
+})
+
+// MARK: Before Resolution
+
 test('beforeResolution interceptor gets called correctly', () => {
   class Bar {}
   const interceptorFn = jest.fn()
@@ -87,7 +182,6 @@ test('beforeResolution multiple interceptors get per their options', () => {
   expect(interceptorFn2).toBeCalledTimes(2)
 })
 
-// beforeResolution .resolveAll() tests
 test('beforeResolution interceptor gets called correctly on resolveAll()', () => {
   class Bar {}
   const interceptorFn = jest.fn()
@@ -97,7 +191,20 @@ test('beforeResolution interceptor gets called correctly on resolveAll()', () =>
   expect(interceptorFn).toBeCalledWith(expect.any(Function), 'All')
 })
 
-// afterResolution .resolve() tests
+test('beforeAnyResolution interceptor gets called on each resolution', () => {
+  class Foo {}
+  class Bar {}
+  const fn = jest.fn()
+
+  globalContainer.beforeAnyResolution(fn)
+  globalContainer.resolve(Foo)
+  globalContainer.resolve(Bar)
+
+  expect(fn).toBeCalledTimes(2)
+})
+
+// MARK: After Resolution
+
 test('afterResolution interceptor gets called correctly', () => {
   class Bar {}
   const interceptorFn = jest.fn()
@@ -185,7 +292,7 @@ test('afterResolution multiple interceptors get called correctly', () => {
   expect(interceptorFn2).toBeCalled()
 })
 
-test('beforeResolution multiple interceptors get per their options', () => {
+test('afterResolution multiple interceptors get per their options', () => {
   class Bar {}
   const interceptorFn1 = jest.fn()
   const interceptorFn2 = jest.fn()
@@ -202,7 +309,6 @@ test('beforeResolution multiple interceptors get per their options', () => {
   expect(interceptorFn2).toBeCalledTimes(2)
 })
 
-// afterResolution resolveAll() tests
 test('afterResolution interceptor gets called correctly on resolveAll()', () => {
   class Bar {}
   const interceptorFn = jest.fn()
@@ -214,4 +320,16 @@ test('afterResolution interceptor gets called correctly on resolveAll()', () => 
     expect.any(Object),
     'All',
   )
+})
+
+test('afterAnyResolution interceptor gets called on each resolution', () => {
+  class Foo {}
+  class Bar {}
+  const fn = jest.fn()
+
+  globalContainer.afterAnyResolution(fn)
+  globalContainer.resolve(Foo)
+  globalContainer.resolve(Bar)
+
+  expect(fn).toBeCalledTimes(2)
 })

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -8,6 +8,23 @@ beforeEach(() => {
   registry = new Registry()
 })
 
+test('tokens returns all registered tokens', () => {
+  registry.set('Foo', {
+    options: { lifecycle: Lifecycle.Singleton },
+    provider: { useValue: 'provider' },
+  })
+  registry.set('Bar', {
+    options: { lifecycle: Lifecycle.Singleton },
+    provider: { useValue: 'provider' },
+  })
+  registry.set('Baz', {
+    options: { lifecycle: Lifecycle.Singleton },
+    provider: { useValue: 'provider' },
+  })
+
+  expect(registry.tokens().length).toBe(3)
+})
+
 test('getAll returns all registrations of a given key', () => {
   const registration1: Registration = {
     options: { lifecycle: Lifecycle.Singleton },

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -1,9 +1,15 @@
 import { RegistryBase } from './registry-base'
 import { InterceptorOptions } from './types'
 import {
+  PostRegistrationInterceptorCallback,
   PostResolutionInterceptorCallback,
   PreResolutionInterceptorCallback,
 } from './types/dependency-container'
+
+export type PostRegistrationInterceptor = {
+  callback: PostRegistrationInterceptorCallback
+  options: InterceptorOptions
+}
 
 export type PreResolutionInterceptor = {
   callback: PreResolutionInterceptorCallback
@@ -15,14 +21,17 @@ export type PostResolutionInterceptor = {
   options: InterceptorOptions
 }
 
+export class PostRegistrationInterceptors extends RegistryBase<PostRegistrationInterceptor> {}
 export class PreResolutionInterceptors extends RegistryBase<PreResolutionInterceptor> {}
-
 export class PostResolutionInterceptors extends RegistryBase<PostResolutionInterceptor> {}
 
 export class Interceptors {
-  public preResolution: PreResolutionInterceptors =
-    new PreResolutionInterceptors()
+  public postRegistration: PostRegistrationInterceptors = new PostRegistrationInterceptors()
+  public postAnyRegistration?: PostRegistrationInterceptorCallback
 
-  public postResolution: PostResolutionInterceptors =
-    new PostResolutionInterceptors()
+  public preResolution: PreResolutionInterceptors = new PreResolutionInterceptors()
+  public preAnyResolution?: PreResolutionInterceptorCallback
+
+  public postResolution: PostResolutionInterceptors = new PostResolutionInterceptors()
+  public postAnyResolution?: PostResolutionInterceptorCallback
 }

--- a/src/registry-base.ts
+++ b/src/registry-base.ts
@@ -3,6 +3,10 @@ import { InjectionToken } from './providers/injection-token'
 export abstract class RegistryBase<T> {
   protected _registryMap = new Map<InjectionToken<any>, T[]>()
 
+  public tokens(): InjectionToken<any>[] {
+    return Array.from(this._registryMap.keys())
+  }
+
   public entries(): IterableIterator<[InjectionToken<any>, T[]]> {
     return this._registryMap.entries()
   }

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -10,6 +10,13 @@ import { RegistrationOptions } from './registration-options'
 
 export type ResolutionType = 'Single' | 'All'
 
+export type PostRegistrationInterceptorCallback<T = any> = {
+  /**
+   * @param token The InjectionToken that was intercepted
+   */
+  (token: InjectionToken<T>): void
+}
+
 export type PreResolutionInterceptorCallback<T = any> = {
   /**
    * @param token The InjectionToken that was intercepted
@@ -82,6 +89,11 @@ export type DependencyContainer = {
   resolveAll<T>(token: InjectionToken<T>): T[]
 
   /**
+   * Gets all registered tokens
+   */
+  registeredTokens(): InjectionToken<any>[]
+
+  /**
    * Check if the given dependency is registered
    *
    * @param token The token to check
@@ -101,6 +113,24 @@ export type DependencyContainer = {
   createChildContainer(): DependencyContainer
 
   /**
+   * Registers a callback that is called when a specific injection token is registered
+   * @param token The token to intercept
+   * @param callback The callback that is called after the token is registered
+   * @param options Options for under what circumstances the callback will be called
+   */
+  afterRegistration<T>(
+    token: InjectionToken<T>,
+    callback: PostRegistrationInterceptorCallback<T>,
+    options?: InterceptorOptions,
+  ): void
+
+  /**
+   * Registers a callback that is called after any registration
+   * @param callback The callback that is called after any registration
+   */
+  afterAnyRegistration(callback: PostRegistrationInterceptorCallback<any>): void
+
+  /**
    * Registers a callback that is called when a specific injection token is resolved
    * @param token The token to intercept
    * @param callback The callback that is called before the token is resolved
@@ -113,6 +143,12 @@ export type DependencyContainer = {
   ): void
 
   /**
+   * Registers a callback that is called before any resolution
+   * @param callback The callback that is called before any resolution
+   */
+  beforeAnyResolution(callback: PreResolutionInterceptorCallback<any>): void
+
+  /**
    * Registers a callback that is called after a successful resolution of the token
    * @param token The token to intercept
    * @param callback The callback that is called after the token is resolved
@@ -123,6 +159,13 @@ export type DependencyContainer = {
     callback: PostResolutionInterceptorCallback<T>,
     options?: InterceptorOptions,
   ): void
+
+  /**
+   * Registers a callback that is called after any successful resolution
+   * @param callback The callback that is called after any resolution
+   * @param options
+   */
+  afterAnyResolution(callback: PostResolutionInterceptorCallback<any>): void
 
   /**
    * Calls `.dispose()` on all disposable instances created by the container.


### PR DESCRIPTION
Added the following functions to `DependencyContainer`:
- `registeredTokens`: Gets all registered tokens
- `afterRegistration`: Registers a callback that is called when a specific injection token is registered
- `afterAnyRegistration`: Registers a callback that is called after any registration
- `beforeAnyResolution`: Registers a callback that is called before any resolution
- `afterAnyResolution`: Registers a callback that is called after any successful resolution